### PR TITLE
Update exception-handler.provider.js

### DIFF
--- a/modular/src/client/app/blocks/exception/exception-handler.provider.js
+++ b/modular/src/client/app/blocks/exception/exception-handler.provider.js
@@ -35,7 +35,7 @@
      * @ngInject
      */
     function config($provide) {
-        $provide.decorator('$exceptionHandler', extendExceptionHandler);
+        $provide.decorator('exceptionHandler', extendExceptionHandler);
     }
 
     /**


### PR DESCRIPTION
Removed a, supposedly, erroneous $-sign from 'exceptionHandler'. I'm not sure why it worked before, but it does not work with newer angular versions and this seems to fix it.